### PR TITLE
Two issues

### DIFF
--- a/GHForPG.js
+++ b/GHForPG.js
@@ -96,12 +96,14 @@ $(function () {
         pinegrow.addEventHandler('on_project_loaded', addToGHMenu);
 
         //Removes extra menu items on project close
-        pinegrow.addEventHandler('on_project_closed', function(pagenull, project) {
-            document.getElementById('stage-changes').remove();
-            document.getElementById('commit-changes').remove();
-        });
+        pinegrow.addEventHandler('on_project_closed', removeFromGHMenu);
 
         function addToGHMenu (pagenull, project) {
+          /* Avoid duplicate entries in the Github menu when opening a project before 
+             closing the active project */
+             if (document.getElementById('stage-changes')) {
+              removeFromGHMenu();
+            }
           let targetMenu = document.getElementById('gh-dropdown');
           let newItems = document.createDocumentFragment();
           let listOne = document.createElement('li');
@@ -116,6 +118,11 @@ $(function () {
           let menuDivider = targetMenu.children.namedItem('ruler-one');
           targetMenu.insertBefore(newItems, menuDivider);
           addAdditionalListeners();
+        }
+
+        function removeFromGHMenu (pagenull, project) {
+          document.getElementById('stage-changes').remove();
+          document.getElementById('commit-changes').remove();
         }
     });
 });

--- a/GHForPG.js
+++ b/GHForPG.js
@@ -84,31 +84,38 @@ $(function () {
         pinegrow.addPluginControlToTopbar(framework, $menu, true, function(){
             addSettingsModal();
             addInitialListeners();
+            // Check if we are opening another project in a new window 
+            if (pinegrow.getCurrentProject()) {
+              addToGHMenu();
+            }
         });
 
-        //Adds project specific GitHub menu items - note need to solve problem with opening
+        //Adds project specific GitHub menu items 
+        //Replaced anonymous callback function with 'addToGHMenu' to solve problem with opening
         //project in a new window not triggering menu addition 
-        pinegrow.addEventHandler('on_project_loaded', function(pagenull, project) {
-            let targetMenu = document.getElementById('gh-dropdown');
-            let newItems = document.createDocumentFragment();
-            let listOne = document.createElement('li');
-            // rjs: removed variables menuItemOne and menuItemTwo
-            listOne.innerHTML = '<a href="#" id="stage-changes">Stage Changes</a>';
-            newItems.appendChild(listOne);
-            let listTwo = document.createElement('li');
-            listTwo.innerHTML = '<a href="#" id="commit-changes">Commit Changes</a>';
-            newItems.appendChild(listTwo);
-            // rjs: using namedITem is more robust then using hardcoded index-number
-            // rjs: this namedItem needs an id on the element <hr> in the menu
-            let menuDivider = targetMenu.children.namedItem('ruler-one');
-            targetMenu.insertBefore(newItems, menuDivider);
-            addAdditionalListeners();
-        });
+        pinegrow.addEventHandler('on_project_loaded', addToGHMenu);
 
         //Removes extra menu items on project close
         pinegrow.addEventHandler('on_project_closed', function(pagenull, project) {
             document.getElementById('stage-changes').remove();
             document.getElementById('commit-changes').remove();
         });
+
+        function addToGHMenu (pagenull, project) {
+          let targetMenu = document.getElementById('gh-dropdown');
+          let newItems = document.createDocumentFragment();
+          let listOne = document.createElement('li');
+          // rjs: removed variables menuItemOne and menuItemTwo
+          listOne.innerHTML = '<a href="#" id="stage-changes">Stage Changes</a>';
+          newItems.appendChild(listOne);
+          let listTwo = document.createElement('li');
+          listTwo.innerHTML = '<a href="#" id="commit-changes">Commit Changes</a>';
+          newItems.appendChild(listTwo);
+          // rjs: using namedITem is more robust then using hardcoded index-number
+          // rjs: this namedItem needs an id on the element <hr> in the menu
+          let menuDivider = targetMenu.children.namedItem('ruler-one');
+          targetMenu.insertBefore(newItems, menuDivider);
+          addAdditionalListeners();
+        }
     });
 });


### PR DESCRIPTION
Hi Bob,
Please, review my solutions for the two problems I mentioned before. I'm not sure if this is the preferred way to go forward. I’m not that experienced in JS.

To solve the problem that the GitHub menu is not completed on opening a new project in a new window I added a check to “addPlugInControlToTopbar” to see if there is a project already open. To enabled this check I made a function out of the anonymous callback function from the “addEventHandler (on-project-loaded)”.
The second problem I addressed, occurs when opening a project (File - open project...) without closing the previous one. In that case entries in the GitHub-menu are doubled.
To solve that I call the new function “removeFromGHMenu” from “addEventHandler (on-project-loaded)”.

René